### PR TITLE
allow writing wrappers around questions.add()

### DIFF
--- a/Plugins/question_source/question_source.py
+++ b/Plugins/question_source/question_source.py
@@ -43,7 +43,7 @@ function encode_uri(t)
 
 def question_lines(c, question):
     start = question.f_lineno
-    while not c[start].startswith('add('):
+    while not c[start].startswith(question.f_name + '('):
         start -= 1
     while start > 0 and c[start].strip() != '':
         start -= 1


### PR DESCRIPTION
It was already possible to write wrapper functions calling add(), but
they raised two issues:

* The full question name infered was "<module>:<function>" where
  <module> was the module containing the wrapper, not the module where
  the wrapper was called. As a consequence, a user splitting code in
  chapter1.py, chapter2.py, and utilities.py would get question names
  like "utilities:<question>" when calling add() through a wrapper
  located in utilities.py.

* The question_source plugin was looking for the string "add(" at the
  beginning of a line.

Fix this by allowing the user to specify the name of the function
actually called to add questions. add() walks the stack to find the
call, and question_source.py uses the function name instead of
hardcoding "add(".